### PR TITLE
Add alternate SEG methods

### DIFF
--- a/R/utils-data-table.R
+++ b/R/utils-data-table.R
@@ -30,5 +30,5 @@ utils::globalVariables(c("age_length", "age_start", "bdays_age_a",
                          "pop_age_a_synthetic_cohort_i", "r1", "r2",
                          "ratio_30d10_20d40", "ratio_30d10_20d40_1",
                          "ratio_30d10_20d40_2", "sex", "sum_growth",
-                         "pop1_copy"))
+                         "pop1_copy", "pop_from_deaths", "pop_from_censuses"))
 

--- a/man/seg.Rd
+++ b/man/seg.Rd
@@ -11,7 +11,8 @@ seg(
   id_cols = c("age_start", "sex"),
   migration = F,
   input_deaths_annual = T,
-  input_migrants_annual = T
+  input_migrants_annual = T,
+  method_numerator_denominator_type = "Nx"
 )
 }
 \arguments{
@@ -49,6 +50,17 @@ Alternative is recorded net migrants for the entire period between census 1
 and census 2. Default TRUE and assumes net migrants are annual. If FALSE,
 migrants will be divided by the decimal number of years between 'date1' and
 'date2'.}
+
+\item{method_numerator_denominator_type}{[\code{character()}]\cr
+Completeness point estimates are population estimated from deaths
+divided by population estimated from censuses. This setting dictates
+the ages the population belongs to. Must be one of:
+\itemize{
+\item "Nx" : numerator and denominator are both estimated population
+aged x. This is the default and matches the GBD methodology.
+\item "nNx" : numerator and denominator are both estimated population
+aged x to x+n. This matches Tim Riffe DDM package and IUSSP methods.
+}}
 }
 \value{
 [\code{list(2)}]\cr

--- a/tests/testthat/test-seg.R
+++ b/tests/testthat/test-seg.R
@@ -58,6 +58,19 @@ test_that("seg without migration works", {
 # setnames(dt_tr, "age_start", "age")
 # # no migration (gives us 1.079)
 # test <- DDM::seg(dt_tr, exact.ages = seq(25, 60, 5), deaths.summed = T)
-# # with migration (gives us 1.026)
-# setnames(dt_tr, "migrants", "mig")
-# test <- DDM::seg(dt_tr, exact.ages = seq(25, 60, 5), deaths.summed = T)
+# # # with migration (gives us 1.026)
+# # setnames(dt_tr, "migrants", "mig")
+# # test <- DDM::seg(dt_tr, exact.ages = seq(25, 60, 5), deaths.summed = T)
+#
+# # test our code with TR numerator denominator type
+# test <- seg(
+#   dt,
+#   age_trim_lower = age_trim_lower,
+#   age_trim_upper = age_trim_upper,
+#   id_cols = id_cols,
+#   migration = F,
+#   input_deaths_annual = F,
+#   input_migrants_annual = F,
+#   method_numerator_denominator_type = "nNx"
+# )
+


### PR DESCRIPTION
## Describe changes

This PR addresses SEG options I think we should test, for cases where our methods deviate from Tim Riffe DDM package.

Namely, I've added the option `method_numerator_denominator_type`. The two options are:
1. GBD (`method_numerator_denominator_type == "Nx"`): completeness = Nx_from_deaths / Nx_from_censuses
2. TR/IUSSP (`method_numerator_denominator_type == "nNx"`): completeness = nNx_from_deaths / nNx_from_censuses

Where Nx is the population aged x and nNx is the population in the age interval x to x+n.

See the details section of this PR for a summary of ways our code differs from TR.

## What issues are related

None

## Checklist

* [x] Have you read the [contributing guidelines](https://github.com/ihmeuw-demographics/packageTemplate/wiki#guide-to-r-package-development) for `ihmeuw-demographics` R packages?
* [x] Have you successfully run `devtools::check()` locally?
* [x] Have you updated or added function (and vignette if applicable) documentation? Did you update the 'man' and 'NAMESPACE' files with `devtools::document()`?
* [x] Have you added in tests for the changes included in the PR?
* [x] Do the changes follow the `ihmeuw-demographics` [code style](https://github.com/ihmeuw-demographics/packageTemplate/wiki/Code-style-guide)?
* [ ] Do the changes need to be immediately included in a new build of [`docker-base`](https://github.com/ihmeuw-demographics/docker-base) or [`docker-internal`](https://github.com/ihmeuw-demographics/docker-internal)? If so follow directions in those repositories to rebuild and redeploy the images.
* [ ] Do the changes require updates to other repositories which use this package? If yes, make the necessary updates in those repos, and consider integration tests for those repositories.

## Details of PR

Ways in which our code differs from TR:

- **Population from censuses:** TR and IUSSP compute population x to x+n. GBD computes population aged x. The `method_numerator_denominator_type` option was added in this PR to create the option to run either method.
- **Age-specific growth rate:** The same, but TR gives option to include migration.
- **Population age x from deaths:** All the same .
- **Population from deaths:** TR and IUSSP take population age x from deaths and use that to estimate population age x to x+n, which they take as the numerator in the completeness ratio.
- **Open age interval life expectancy:**  TR uses CD West life tables. GBD uses mostly CD West but with a small number of exceptions. TR does interpolation between life table levels using splines. GBD does analytic interpolation. Both match to CD level using ratio 30d10 to 20d40, and compute ndx from deaths and population in the same way (following Bennett and Horiuchi paper).
- **Age trims:** TR has option for automatic age trim selection based on RMSE. We use best age trim from simulation, but same age trim for all location-years.
- **Synthesis:** Everyone uses a simple mean.

See Hub page table for more details: https://hub.ihme.washington.edu/display/DRT/DDM

@haidong Given this summary of differences, please let me know if there are toggles other than the numerator/denominator method that you want me to be including and testing. Thanks.

Note that these are the values I'm getting on the South Africa example dataset:
- `DDMethods` w/o migration, w/ "Nx" method: 1.088509
- `DDMethods` w/o migration, w/ "nNx" method: 1.082785
- TR `DDM` w/o migration: 1.07976

So using the `nNx` method is getting me closer to the TR output, but it still isn't identical, meaning there's residual difference in methods. Perhaps that's coming from the different CD West interpolation.